### PR TITLE
Reword the Meshtastic configuration details, on the homepage.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ nyme.sh is a group of enthusiasts who love Meshtastic! Most of us are in the New
 
 ## Current Meshtastic Settings
 
-The main nyme.sh [Meshtastic](https://meshtastic.org) network is migrating to `Medium Range - Slow` preset, Frequency Slot `48`. See the [recommended configuration](/getting-started#meshtastic) for Meshtastic nodes.
+The main nyme.sh [Meshtastic](https://meshtastic.org) network is migrating to a mostly **custom** configuration, which includes a ***non**-default* Frequency Slot. See the [recommended configuration](/getting-started#meshtastic) for Meshtastic nodes.
 
 
 ## Preset Testing


### PR DESCRIPTION
Based on this discussion in the Discord: https://discord.com/channels/1395794339329998970/1395806815672864929/1481106867014078746

The goal is to incentivize users to visit the full `getting-started.md` webpage, which has both the details about the non-default Radio Preset and Frequency Slot, but also some other settings that are very beneficial to the health of the mesh as a whole.