### PR TITLE
Clean up config

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -29,10 +29,10 @@
           </a>
           <a href="/">Home</a>
           <a href="/getting-started/">Getting Started</a>
-          <hr />
+          <!-- <hr />
           <a href="/node_configuration/">Config</a>
           <a href="/node_configuration_adv/">Advanced Config</a>
-          <a href="/build_resources/">Builds</a>
+          <a href="/build_resources/">Builds</a> -->
           <hr />
           <a href="/faq/">FAQ</a>
           <a href="/glossary/">Glossary</a>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -326,7 +326,7 @@ details summary {
 dt {
   float: left;
   clear: left;
-  width: 12em;
+  width: 10em;
   &::after {
     content: ':';
   }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,7 +153,7 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
 
 To connect to the wide-area MeshCore network in the NYC area:
 
-1. Ensure your companion node or repeater is on the [latest firmware](https://flasher.meshcore.co.uk)
+1. Ensure your companion is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mt-companion-firmware"></span>
 
 <div class="callout" id="meshcore-radio-settings">
   <p>MeshCore radio settings:</p>
@@ -177,8 +177,9 @@ To connect to the wide-area MeshCore network in the NYC area:
 
 For repeaters:
 
-1. Set zero-hop auto advert interval to <u>360 minutes</u> or more
-2. Set flood auto advert interval to <u>24 hours</u> or more
+1. Ensure your repeater is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mt-repeater-firmware"></span>
+2. Set zero-hop auto advert interval to <u>360 minutes</u> or more
+3. Set flood auto advert interval to <u>24 hours</u> or more
 
 
 <script>
@@ -227,11 +228,19 @@ For repeaters:
 
 <script>
   (async function () {
-    const req = await fetch('https://api.meshtastic.org/github/firmware/list');
-    const { releases } = await req.json();
-    if (releases.stable?.[0]?.id) {
+    const req = await fetch('https://prod-operator.fly.dev/api/firmware/latest);
+    const { meshtastic, meshcore } = await req.json();
+    if (meshtastic?.stable) {
       const el = document.querySelector('.js-mt-firmware');
-      el.textContent = ` (${ releases.stable[0].id.replace(/\.[\w]+$/,'') }+)`;
+      el.textContent = ` (${ meshtastic.stable.replace(/\.[\w]+$/,'') }+)`;
+    }
+    if (meshcore?.companion) {
+      const el = document.querySelector('.js-mc-companion-firmware');
+      el.textContent = ` (${ meshcore.companion.replace(/\.[\w]+$/,'') }+)`;
+    }
+    if (meshcore?.repeater) {
+      const el = document.querySelector('.js-mc-repeater-firmware');
+      el.textContent = ` (${ meshcore.repeater.replace(/\.[\w]+$/,'') }+)`;
     }
   })();
 </script>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,7 +159,7 @@ To connect to the wide-area MeshCore network in the NYC area:
   <p>MeshCore radio settings:</p>
   <dl>
     <dt>Preset</dt>
-    <dd><u>US/Canada recommended</u></dd>
+    <dd><u>US/Canada</u></dd>
     <dt>Frequency</dt>
     <dd><u>910.525 MHz</u></dd>
     <dt>Bandwidth</dt>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,23 +15,30 @@ If you don’t already have a device, see our list of [recommended complete node
 
 ## Meshtastic
 
-To connect to the wide-area Meshtastic network in the NYC area…
+To connect to the wide-area Meshtastic networks in the NYC area…
 
 1. Ensure your node is on the [latest Beta or Alpha firmware](https://flasher.meshtastic.org)<span class="js-mt-firmware"></span>
 2. (optional) Enable LoRa &gt; Ok To MQTT to show on the [map/chat](https://meshview.nyme.sh/map)
+3. Configure your node as described below, based on how you use it:
 
-### Personal/handheld/mobile node configuration
+### Personal node configuration
+
+These are nodes that you send messages from. Either fixed or mobile.
+
+#### Handheld node config
+
+These are nodes that you carry with you, in your pocket, bag, belt, mounted on your car, and so on.
 
 1. Role: <u>CLIENT_MUTE</u>
 2. Position: <u>disabled</u>, or
     - <u>enable</u> smart position
         - smart interval <u>30 minutes</u> or more
-        - update distance <u>100<u> or more
+        - update distance <u>100 m<u> or more
     - <u>disable</u> altitude
     - GPS polling interval: <u>30 minutes</u> or longer
 3. Telemetry: <u>off</u>
 4. Device info: <u>18 hour</u> interval or longer
-5. LoRa <span class="js-konami" data-alt="bunny">hop</span> limit: <u>5</u>
+5. LoRa <span class="js-konami" data-alt="bunny">hop</span> limit: <u>7</u>
 
 <details class="small">
   <summary>Explanation of the settings</summary>
@@ -39,30 +46,60 @@ To connect to the wide-area Meshtastic network in the NYC area…
   <p>Smart position is preferred because it reduces the broadcasts if position hasn’t changed. However, it has trouble with altitude so it’s best to disable this—altitude is usually not helpful for mobile nodes. Generally, position doesn’t need to be sent more frequently than 30 minutes.</p>
   <p>Telemetry is disabled because we don’t need to know your battery level or channel utilization on a regular basis. Neither are meaningful to the rest of the mesh.</p>
   <p>Reducing automatic device info broadcasts avoids the throttling that inhibits the request user info features, and it makes room for more useful packets generally. Also, nodes have the ability to send node info on-demand if the operator needs to advertise their info.</p>
-  <p>Personal nodes usually need more <span class="js-konami" data-alt="bunnies">hops</span> to work through the infill to get to and from the network backbone. On the next-gen MediumSlow network (see below) this changes to the maximum of <em>7</em> because the network adopts <a href="/nymesh-2/">packet-level resliency</a> instead of link-level, and needs the additional <span class="js-konami" data-alt="bunnies">hops</span> to allow for retries.</p>
+  <p>Personal nodes usually need more <span class="js-konami" data-alt="bunnies">hops</span> to work through the infill to get to and from the network backbone. The next-gen MediumSlow network relies on this being the maximum of <em>7</em> because the network adopts <a href="/nymesh-2/">packet-level resiliency</a> instead of link-level, and needs the additional <span class="js-konami" data-alt="bunnies">hops</span> to allow for retries and path diversity.</p>
 </details>
 <br>
 
-### Stationary/fixed node configuration
+#### Stationary personal node config
 
-1. Role: <u>CLIENT_BASE</u><sup><a href="/faq#what-role-do-i-chose">*</a></sup>
+These are your base station nodes that live on your desk or your roof, _that you also send messages from_. They are nodes you connect directly to, rather than use as a relay. (If you _do not_ send messages directly from the roof node, see [below](#infrastructure-node-configuration).)
+
+1. Role: <u>CLIENT</u>
 2. Position: <u>disabled</u>, or
     - <u>disable</u> smart position
     - <u>enable</u> altitude
     - fixed position recommended
     - GPS polling interval (if applicable): <u>24 hours</u>
     - broadcast interval: <u>24 hour</u> interval or longer
-3. Telemetry: <u>off</u>, or at least <u>6 hour</u> interval if remote
-4. Device info: <u>24 hour</u> interval
-5. LoRa <span class="js-konami" data-alt="bunny">hop</span> limit: <u>3</u>
-6. (Optional) Enable <a href="https://meshtastic.org/docs/configuration/remote-admin/">remote admin</a>
+3. Telemetry: <u>off</u>.
+4. Device info: <u>18 hour</u> interval or longer
+5. LoRa <span class="js-konami" data-alt="bunny">hop</span> limit: <u>7</u>
 
 <details class="small">
   <summary>Explanation of the settings</summary>
-  <p><code>CLIENT_BASE</code> helps differentiate the fixed nodes from mobile nodes. It also enables handy infrastructure behaviors through favoriting adjacent routers and personal nodes, features that work best when the node is in a static position.</p>
+  <p><code>CLIENT</code> is the preferred starting point for fixed personal nodes because they are likely to provide useful conditional relay.</p>
+  <p>Position is optional, but helpful to understand the physical realities of the mesh. Smart position is not recommended, since the node is not moving. It can have trouble with variations from a GPS fix so it’s best to set an explicit fixed position. Altitude is helpful for understanding coverage.</p>
+  <p>Telemetry is preferred disabled because others generally don’t need to know your battery level or channel utilization on a regular basis. Neither are meaningful to the rest of the mesh. The node will still relay its battery info regularly when you connect your app to it.</p>
+  <p>Reducing automatic device info broadcasts avoids the throttling that inhibits the request user info features, and it makes room for more useful packets generally. Also, nodes have the ability to send node info on-demand if the operator needs to advertise their info.</p>
+  <p>Personal nodes usually need more <span class="js-konami" data-alt="bunnies">hops</span> to work through the infill to get to and from the network backbone. The next-gen MediumSlow network relies on this being the maximum of <em>7</em> because the network adopts <a href="/nymesh-2/">packet-level resiliency</a> instead of link-level, and needs the additional <span class="js-konami" data-alt="bunnies">hops</span> to allow for retries and path diversity.</p>
+</details>
+<br>
+
+
+### Infrastructure node configuration
+
+Nodes that are in a fixed location and intended solely for relay purposes. These nodes are _not_ used to send messages directly. They typically are solar builds in remote locations. (If you _do_ send messages from the node, see [above](#stationary-personal-node-config).)
+
+1. Role: <u>CLIENT_BASE</u><sup><a href="/faq#what-role-do-i-chose">*</a></sup>
+2. Is Unmessagable: <u>true</u>
+3. Position:
+    - <u>disable</u> smart position
+    - <u>enable</u> altitude
+    - fixed position recommended
+    - GPS polling interval (if applicable): <u>24 hours</u>
+    - broadcast interval: <u>24 hour</u> interval or longer
+4. Telemetry: at least <u>6 hour</u> interval
+5. Device info: <u>48 hour</u> interval
+6. LoRa <span class="js-konami" data-alt="bunny">hop</span> limit: <u>2</u>
+7. (Optional, _strongly recommended_) Enable <a href="https://meshtastic.org/docs/configuration/remote-admin/">remote admin</a>
+
+<details class="small">
+  <summary>Explanation of the settings</summary>
+  <p><code>CLIENT_BASE</code> helps differentiate the infrastructure nodes from personal nodes. It also enables handy infrastructure behaviors through favoriting adjacent routers and personal nodes, features that work best when the node is in a static position. <code>CLIENT_BASE</code> is also the recommended starting point even if the node is particulary well situated.</p>
   <p>Altitude is useful for line-of-sight estimates. But smart position has trouble with altitude if it changes due to GPS variation and can spam position unnecessarily. 24 hours is sufficient to stay on the map.</p>
-  <p>Fixed position is recommended even if there is GPS present. The GPS is still useful for keeping the node's clock accurate, but it can cause unexpected position variations due to errant GPS signal reception.</p>
-  <p>Telemetry broadcasts on a local node are unnecessary. If the node is remote, 6 hours or longer is sufficient to know its health.</p>
+  <p>Position is highly recommended for infrastructure nodes so users can understand which nodes provide coverage for them. (It doesn’t have to be exact, but should be a useful approximation.) Fixed position is recommended even if there is GPS present. The GPS is still useful for keeping the node's clock accurate, but it can cause unexpected position variations due to errant GPS signal reception. 24 hours is sufficient to maintain the clock without a meaningful drain on the battery of solar nodes.</p>
+  <p>Telemetry broadcasts are useful to monitor the health of the node, but more frequent than 6 hours is excessive and takes up useful airtime.</p>
+  <p>Device info is significantly curtailed because it’s not necessary for the nodes to route packets, and takes up airtime.</p>
   <p><span class="js-konami" data-alt="Bunny">Hop</span> limit: fixed nodes should focus on advertising to their immediate vicinity. They also should be within direct or single-<span class="js-konami" data-alt="bunny">hop</span> range of infrastructure, and don’t need as many <span class="js-konami" data-alt="bunnies">hops</span> to reach through the infill — they <em>are</em> the infill.</p>
 </details>
 <br />
@@ -71,7 +108,7 @@ To connect to the wide-area Meshtastic network in the NYC area…
 ### Radio settings
 
 <div class="callout -primary" id="mediumslow">
-  <p><strong>Please ensure your node follows the <a href="#personalhandheldmobile-node-configuration">above configuration</a> before connecting to the network.</strong></p>
+  <p><strong><em>Please</em> ensure your node follows the <a href="#personalhandheldmobile-node-configuration">above configuration</a> before connecting to the network.</strong></p>
   <p>Current primary mesh radio settings:</p>
   <dl>
     <dt>Preset</dt>
@@ -140,8 +177,8 @@ To connect to the wide-area MeshCore network in the NYC area:
 
 For repeaters:
 
-1. Set zero-hop auto advert interval to <u>180 minutes</u> or more
-2. Set flood auto advert interval to <u>12 hours</u> or more
+1. Set zero-hop auto advert interval to <u>360 minutes</u> or more
+2. Set flood auto advert interval to <u>24 hours</u> or more
 
 
 <script>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,6 +107,8 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
 
 ### Radio settings
 
+There are currently two different Meshtastic networks operating in the NYC area. Joining a network requires configuring your radio to use the same LoRa settings. You are free to join whichever one you can reach, or both if you have multiple devices.
+
 <div class="callout -primary" id="mediumslow">
   <p><strong><em>Please</em> ensure your node follows the <a href="#personalhandheldmobile-node-configuration">above configuration</a> before connecting to the network.</strong></p>
   <p>Current primary mesh radio settings:</p>
@@ -124,7 +126,7 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
     Personal nodes: increase LoRa <span class="js-konami" data-alt="bunny">hop</span> limit to <u>7</u>. (Yes, really.)
   </p>
   <p class="small">
-    The network is actively <a href="/preset-testing/">migrating</a> to MediumSlow. Not all infrastructure has moved yet. You may find it difficult to reach some parts of the network during the transition. Network status and help is available in the <a href="https://discord.nyme.sh">Discord chat</a>.
+    This network is <a href="/preset-testing/">actively forming</a>. Not all infrastructure has moved yet. You may find it difficult to reach some parts of the network during the transition. Network status and help is available in the <a href="https://discord.nyme.sh">Discord chat</a>.
   </p>
 </div>
 
@@ -140,6 +142,9 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
     <dt>Public channel key</dt>
     <dd><u>1 byte</u>, <u><code>AQ==</code></u></dd>
   </dl>
+  <p class="small">
+    These settings are the default, out-of-the-box Meshtastic settings. A bit of infrastructure is maintained on these settings to catch newcomers, travelers, and stragglers. Some users continue with this network since it provides the greater range that they need (at the expense of severe congestion).
+  </p>
 </div>
 
 <details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ These are nodes that you carry with you, in your pocket, bag, belt, mounted on y
 2. Position: <u>disabled</u>, or
     - <u>enable</u> smart position
         - smart interval <u>30 minutes</u> or more
-        - update distance <u>100 m<u> or more
+        - update distance <u>100 m</u> or more
     - <u>disable</u> altitude
     - GPS polling interval: <u>30 minutes</u> or longer
 3. Telemetry: <u>off</u>
@@ -95,7 +95,7 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
 
 <details class="small">
   <summary>Explanation of the settings</summary>
-  <p><code>CLIENT_BASE</code> helps differentiate the infrastructure nodes from personal nodes. It also enables handy infrastructure behaviors through favoriting adjacent routers and personal nodes, features that work best when the node is in a static position. <code>CLIENT_BASE</code> is also the recommended starting point even if the node is particulary well situated.</p>
+  <p><code>CLIENT_BASE</code> helps differentiate the infrastructure nodes from personal nodes. It also enables handy infrastructure behaviors through favoriting adjacent routers and personal nodes, features that work best when the node is in a static position. <code>CLIENT_BASE</code> is also the recommended starting point even if the node is well sited.</p>
   <p>Altitude is useful for line-of-sight estimates. But smart position has trouble with altitude if it changes due to GPS variation and can spam position unnecessarily. 24 hours is sufficient to stay on the map.</p>
   <p>Position is highly recommended for infrastructure nodes so users can understand which nodes provide coverage for them. (It doesn’t have to be exact, but should be a useful approximation.) Fixed position is recommended even if there is GPS present. The GPS is still useful for keeping the node's clock accurate, but it can cause unexpected position variations due to errant GPS signal reception. 24 hours is sufficient to maintain the clock without a meaningful drain on the battery of solar nodes.</p>
   <p>Telemetry broadcasts are useful to monitor the health of the node, but more frequent than 6 hours is excessive and takes up useful airtime.</p>
@@ -110,7 +110,7 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
 There are currently two different Meshtastic networks operating in the NYC area. Joining a network requires configuring your radio to use the same LoRa settings. You are free to join whichever one you can reach, or both if you have multiple devices.
 
 <div class="callout -primary" id="mediumslow">
-  <p><strong><em>Please</em> ensure your node follows the <a href="#personalhandheldmobile-node-configuration">above configuration</a> before connecting to the network.</strong></p>
+  <p><strong><em>Please</em> ensure your node follows the <a href="#personal-node-configuration">above configuration</a> before connecting to the network.</strong></p>
   <p>Current primary mesh radio settings:</p>
   <dl>
     <dt>Preset</dt>
@@ -123,7 +123,7 @@ There are currently two different Meshtastic networks operating in the NYC area.
     <dd><u>1 byte</u>, <u><code>AQ==</code></u></dd>
   </dl>
   <p>
-    Personal nodes: increase LoRa <span class="js-konami" data-alt="bunny">hop</span> limit to <u>7</u>. (Yes, really.)
+    <strong>Personal nodes: increase LoRa <span class="js-konami" data-alt="bunny">hop</span> limit to <u>7</u>.</strong> (Yes, really.)
   </p>
   <p class="small">
     This network is <a href="/preset-testing/">actively forming</a>. Not all infrastructure has moved yet. You may find it difficult to reach some parts of the network during the transition. Network status and help is available in the <a href="https://discord.nyme.sh">Discord chat</a>.
@@ -158,7 +158,7 @@ There are currently two different Meshtastic networks operating in the NYC area.
 
 To connect to the wide-area MeshCore network in the NYC area:
 
-1. Ensure your companion is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mt-companion-firmware"></span>
+1. Ensure your companion is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mc-companion-firmware"></span>
 
 <div class="callout" id="meshcore-radio-settings">
   <p>MeshCore radio settings:</p>
@@ -182,7 +182,7 @@ To connect to the wide-area MeshCore network in the NYC area:
 
 For repeaters:
 
-1. Ensure your repeater is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mt-repeater-firmware"></span>
+1. Ensure your repeater is on the [latest firmware](https://flasher.meshcore.io) <span class="js-mc-repeater-firmware"></span>
 2. Set zero-hop auto advert interval to <u>360 minutes</u> or more
 3. Set flood auto advert interval to <u>24 hours</u> or more
 
@@ -233,7 +233,7 @@ For repeaters:
 
 <script>
   (async function () {
-    const req = await fetch('https://prod-operator.fly.dev/api/firmware/latest);
+    const req = await fetch('https://prod-operator.fly.dev/api/firmware/latest');
     const { meshtastic, meshcore } = await req.json();
     if (meshtastic?.stable) {
       const el = document.querySelector('.js-mt-firmware');

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,7 +24,7 @@ A list of terminology often used when discussing mesh and radio topics (US-centr
 - **CLIENT_BASE:** a Meshtastic role that conditionally repeats packets after ROUTERs, with additional behaviors intended for fixed nodes
 - **coding rate (CR):** the amount of redundant bits included in a LoRa transmission, increasing signal resiliency at the cost of airtime
 - **dB:** [Decibel](https://en.wikipedia.org/wiki/Decibel), a measure of signal power ratios
-- **dBi:** a measure of antenna gain in dB with respect to a dipole antenna
+- **dBd:** a measure of antenna gain in dB with respect to a dipole antenna
 - **dBi:** a measure of antenna gain in dB with respect to a theoretical isotropic radiator
 - **dBm:** a measure of power in dB with respect to milliwatts, 30 dBm equals 1 Watt
 - **digipeater:** an APRS node that repeats packets
@@ -38,6 +38,7 @@ A list of terminology often used when discussing mesh and radio topics (US-centr
 - **flash:** the process of updating the firmware of the node
 - **flasher:** the [tool](https://flasher.meshtastic.org) used to update firmware
 - **FRS:** Family Radio Service, a channelized portion of UHF spectrum allocated for unlicensed use, “walkie talkies”
+- **gain**: an increase in signal strength through passive or active means
 - **gateway:** a node that uplinks packets to, or downlinks from, MQTT
 - **GMRS:** General Mobile Radio Service, a channelized portion of UHF spectrum licensed by the FCC
 - **ham:** someone with an Amateur Radio License, aka Ham Radio (_not_ an acronym or initialism)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,6 @@
+---
+title: Glossary
+---
 
 # Glossary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 nyme.sh is a group of enthusiasts who love Meshtastic! Most of us are in the New York City metro area, but anyone with an interest is invited to join—no matter where you’re from. If you’re curious about Meshtastic or other mesh radio technologies, we’d love to have you be part of our community! Join us on Discord to chat with the crew.  See you there ;)
 
-- See [**Getting Started**](/getting-started) to get up and running with the area network
+- See [**Getting Started**](/getting-started) to get up and running with the area networks
 - Join us on Discord: [discord.nyme.sh](https://discord.nyme.sh)
 
 (If you’re looking for the mesh WiFi network, see [NYC Mesh](https://www.nycmesh.net/).)

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1,4 +1,6 @@
-
+---
+title: MQTT
+---
 # dracoling's quick guide to MQTT in the nyme.sh
 
 MQTT is used by [meshview](https://meshview.nyme.sh) and our other services to collect, collate, and distribute packet information from devices all over the mesh.

--- a/docs/nymesh-2.md
+++ b/docs/nymesh-2.md
@@ -1,4 +1,11 @@
+---
+title: NYMesh 2.0
+date: 2025-12-03
+---
+
 # nyme.sh 2.0
+
+2025 December 3
 
 There’s a crystallizing pattern for functional metro-scale meshes: __favor infrastructure with predictable relay behavior across reliable links, and minimize airtime__.
 
@@ -120,6 +127,8 @@ A few realistically situated nodes. Ideally a mix of construction, with and with
 
 This is a bit of a circular dependency, since a proper test network needs filters but [investing in filters](https://discord.com/channels/1395794339329998970/1441831475602522162) requires choosing a frequency which requires testing presets. SDR sweeps should help.
 
+Update: [settled on 913.875 MHz](/preset-testing/) (aka slot 48).
+
 ### Plan actual cutover
 
-TBD
+Update, 2026 February 18: it has [begun](/getting-started/#mediumslow).


### PR DESCRIPTION
Improves the getting-started config to clarify the difference between fixed nodes that still send messages and infrastructure nodes. Also hides some stale documentation for the moment (will follow with revised docs later), and fixes the firmware version lookup.