### PR TITLE
Add request to not use high-traffic applications

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -40,6 +40,7 @@
           <a href="https://discord.nyme.sh">Discord</a>
           <a href="https://meshview.nyme.sh">Meshview</a>
           <a href="https://malla.nyme.sh">Malla</a>
+          <a href="https://coverage.nyme.sh">Coverage</a>
         </div>
       </div>
     </nav>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ Nodes that are in a fixed location and intended solely for relay purposes. These
 There are currently two different Meshtastic networks operating in the NYC area. Joining a network requires configuring your radio to use the same LoRa settings. You are free to join whichever one you can reach, or both if you have multiple devices.
 
 <div class="callout -primary" id="mediumslow">
-  <p><strong><em>Please</em> ensure your node follows the <a href="#personal-node-configuration">above configuration</a> before connecting to the network.</strong></p>
+  <p><strong>Be a good mesh citizen:</strong> <em>Please</em> ensure your node follows the <a href="#personal-node-configuration">above configuration</a> before connecting to the network. Please do not use high-traffic applications like Reticulum or TAK on this network; they saturate the mesh and make it unusable for everyone. Sustained encrypted traffic will be detected and blocked by the infrastructure to protect the limited airtime.</p>
   <p>Current primary mesh radio settings:</p>
   <dl>
     <dt>Preset</dt>


### PR DESCRIPTION
To better ensure people know in advance that tools like Reticulum or TAK should not be used on the public network. 

(Currently the blocking is manual and at the discretion of the infrastructure operators but the forthcoming [traffic management module](https://github.com/meshtastic/firmware/pull/9358) will perform this traffic shaping automatically if operators choose to enable it.)